### PR TITLE
fix: firewall rule name

### DIFF
--- a/main.firewallrule.tf
+++ b/main.firewallrule.tf
@@ -2,7 +2,7 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "this" {
   for_each = var.firewall_rules
 
   end_ip_address   = each.value.end_ip_address
-  name             = each.key
+  name             = each.value.name
   server_id        = azurerm_postgresql_flexible_server.this.id
   start_ip_address = each.value.start_ip_address
 }


### PR DESCRIPTION
## Description

Fixes #40

Firewall rule name set from from map key instead of name.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
