### PR TITLE
Made firewall rules to be nullable if no one is needed

### DIFF
--- a/main.firewallrule.tf
+++ b/main.firewallrule.tf
@@ -1,5 +1,5 @@
 resource "azurerm_postgresql_flexible_server_firewall_rule" "this" {
-  for_each = var.firewall_rules
+  for_each = var.firewall_rules != null ? var.firewall_rules : {}
 
   end_ip_address   = each.value.end_ip_address
   name             = each.key


### PR DESCRIPTION
## Description

Variable `firewall_rules` now can be `null` and this will not deploy anyone.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
